### PR TITLE
#29 fix bugs occurred while testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ nlpaug==1.1.3
 wget==3.2
 spacy==3.0.5
 haystack
-nltk==3.6.3
+nltk==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18.5
+numpy==1.17
 pandas==1.1.5
 scikit-learn==0.24.1
 nlpaug==1.1.3

--- a/tests/test_DataAugmenterInternally.py
+++ b/tests/test_DataAugmenterInternally.py
@@ -18,9 +18,12 @@ the two samples are the same.
 Conversely, we can reject the null hypothesis if the p-value is low.
 """
 
-N_TO_CHECK = 500
-SIG = 3
-N_SIG = 0.33
+np.random.seed(32)
+
+N_TO_CHECK = 200_000
+MEAN = 0
+SIG = 1
+N_SIG = 3
 
 
 @pytest.fixture
@@ -35,12 +38,16 @@ def empty_data():
 
 @pytest.fixture
 def normal_data():
-    return pd.Series(np.random.normal(0, SIG * 3, size=N_TO_CHECK), dtype="float64")
+    return pd.Series(
+        np.random.normal(MEAN, SIG * N_SIG, size=N_TO_CHECK), dtype="float64"
+    )
 
 
 @pytest.fixture
 def uniform_data():
-    return pd.Series(np.random.uniform(0, SIG * 3, size=N_TO_CHECK), dtype="float64")
+    low = -SIG
+    high = SIG
+    return pd.Series(np.random.uniform(low, high, size=N_TO_CHECK))
 
 
 def test_augment_column(dai, empty_data):
@@ -91,6 +98,8 @@ def test_augment_column_norm_2(dai, normal_data):
     normal_data_aug = dai.augment_column_norm(
         normal_data,
         freq=1,
+        mean=MEAN,
+        sigm=SIG,
         n_sigm=N_SIG,
         n_to_aug=N_TO_CHECK,
         return_only_aug=True,
@@ -120,7 +129,8 @@ def test_augment_column_uniform_2(dai, uniform_data):
     uniform_data_aug = dai.augment_column_uniform(
         uniform_data,
         freq=1.0,
-        n_sigm=N_SIG,
+        min_=-SIG,
+        max_=SIG,
         n_to_aug=N_TO_CHECK,
         return_only_aug=True,
     )

--- a/zarnitsa/stats/DataAugmenterInternally.py
+++ b/zarnitsa/stats/DataAugmenterInternally.py
@@ -122,7 +122,14 @@ class DataAugmenterInternally(AbstractDataAugmenter):
         return to_aug if return_only_aug else pd.concat([not_to_aug, to_aug])
 
     def augment_column_norm(
-        self, col: pd.Series, n_to_aug=0, freq=0.2, n_sigm=3, return_only_aug=False
+        self,
+        col: pd.Series,
+        mean=None,
+        sigm=None,
+        n_to_aug=0,
+        freq=0.2,
+        n_sigm=3,
+        return_only_aug=False,
     ) -> pd.Series:
         """
         Augment column data using normal distribution. Pandas column
@@ -135,9 +142,10 @@ class DataAugmenterInternally(AbstractDataAugmenter):
         if not col.shape[0]:
             raise ValueError(f"Iterable object <{type(col)}> is empty! Check input!")
         not_to_aug, to_aug = self._prepare_data_to_aug(col, freq=freq)
-        column_std = col.std()
+        columns_mean = col.mean() if not mean else mean
+        column_std = col.std() if not sigm else sigm
         to_aug = to_aug.apply(
-            lambda value: np.random.normal(value, n_sigm * column_std)
+            lambda value: np.random.normal(columns_mean, n_sigm * column_std)
         )
         if n_to_aug:
             n_to_aug = min(n_to_aug, to_aug.shape[0])
@@ -145,7 +153,13 @@ class DataAugmenterInternally(AbstractDataAugmenter):
         return to_aug if return_only_aug else pd.concat([not_to_aug, to_aug])
 
     def augment_column_uniform(
-        self, col: pd.Series, n_to_aug=0, freq=0.2, n_sigm=3, return_only_aug=False
+        self,
+        col: pd.Series,
+        min_=None,
+        max_=None,
+        n_to_aug=0,
+        freq=0.2,
+        return_only_aug=False,
     ) -> pd.Series:
         """
         Augment column data using uniform distribution. Pandas column
@@ -158,12 +172,9 @@ class DataAugmenterInternally(AbstractDataAugmenter):
         if not col.shape[0]:
             raise ValueError(f"Iterable object <{type(col)}> is empty! Check input!")
         not_to_aug, to_aug = self._prepare_data_to_aug(col, freq=freq)
-        column_std = col.std()
-        to_aug = to_aug.apply(
-            lambda value: np.random.uniform(
-                value - n_sigm * column_std, value + n_sigm * column_std
-            )
-        )
+        min_ = col.min() if not min_ else min_
+        max_ = col.max() if not max_ else max_
+        to_aug = to_aug.apply(lambda value: np.random.uniform(min_, max_))
         if n_to_aug:
             n_to_aug = min(n_to_aug, to_aug.shape[0])
             to_aug = to_aug.sample(n_to_aug)


### PR DESCRIPTION
1. FAILED tests/test_DataAugmenterInternally.py::test_augment_column_norm_2 - AssertionError: KS criteria
2. FAILED tests/test_DataAugmenterNLP.py::test_augment_wordnet - TypeError: tokens: expected a list of strings, got a string
3. FAILED tests/test_DataAugmenterNLP.py::test_augment_emb_2 - OSError: [E050] Can't find model 'en_core_web_md'. It doesn't seem to be a Python package or a valid path to a data directory.

was solved:
1. increased number of examples, set random seed value in test, more setting more obvious params (prior knowledge) and fixed some shitty code in DataAugmenterInternally
2. reduced nltk version
3. model wasn't before running using command   `python -m spacy download en_core_web_md`
